### PR TITLE
upgrade to newer release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
     minio:
         restart: always
-        image: minio/minio:RELEASE.2021-06-14T01-29-23Z
+        image: minio/minio:RELEASE.2021-10-02T16-31-05Z
         container_name: mlflow_s3
         expose:
             - "9000"
@@ -11,8 +11,8 @@ services:
         networks: 
             - storage
         environment:
-            - MINIO_ACCESS_KEY=${AWS_ACCESS_KEY_ID}
-            - MINIO_SECRET_KEY=${AWS_SECRET_ACCESS_KEY}
+            - MINIO_ROOT_USER=${AWS_ACCESS_KEY_ID}
+            - MINIO_ROOT_PASSWORD=${AWS_SECRET_ACCESS_KEY}
         volumes:
             - minio_data:/data
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
         container_name: mlflow_s3
         expose:
             - "9000"
-        command: server /data
+            - "9001"
+        command: server /data --console-address ':9001' --address ':9000'
         networks: 
             - storage
         environment:
@@ -77,6 +78,7 @@ services:
         ports:
             - "80:80"
             - "9000:9000"
+            - "9001:9001"
         networks:
             - frontend
             - storage

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,3 +6,4 @@ COPY nginx.conf /etc/nginx
 # Copy proxy config
 COPY mlflow.conf /etc/nginx/sites-enabled/
 COPY minio.conf /etc/nginx/sites-enabled/
+COPY web.conf /etc/nginx/sites-enabled/

--- a/nginx/web.conf
+++ b/nginx/web.conf
@@ -1,7 +1,7 @@
 # Define the parameters for a specific virtual host/server
 server {
     # Define the server name, IP address, and/or port of the server
-    listen 9000;
+    listen 9001;
 
     # Define the specified charset to the “Content-Type” response header field
     charset utf-8;
@@ -27,6 +27,6 @@ server {
         proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
-        proxy_pass http://minio:9000;
+        proxy_pass http://minio:9001;
     }
 }


### PR DESCRIPTION
some changes with the web interface seem to disallow hosting the web + api on the same port. I made them distinct and explicit, as well as upgraded the environment variables.

`docker logs mlflow_s3` now show no warnings/errors and the web ui is accessible (the upgrade is a very nice one!)